### PR TITLE
Allow non booted kernel compilation

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $EUID -ne 0 ]]; then
-  echo "You must run this with superuser priviliges.  Try \"sudo ./dkms-install.sh\"" 2>&1
+  echo "You must run this with superuser privileges.  Try \"sudo ./dkms-install.sh\"" 2>&1
   exit 1
 else
   echo "About to run dkms install steps..."

--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -10,12 +10,13 @@ fi
 DRV_DIR="$(pwd)"
 DRV_NAME=r8125
 DRV_VERSION=9.015.00
+KERNEL_VERSION="${KERNEL_VERSION:-$(uname -r)}"
 
 cp -r ${DRV_DIR} /usr/src/${DRV_NAME}-${DRV_VERSION}
 
-dkms add -m ${DRV_NAME} -v ${DRV_VERSION}
-dkms build -m ${DRV_NAME} -v ${DRV_VERSION}
-dkms install -m ${DRV_NAME} -v ${DRV_VERSION}
+dkms add -m ${DRV_NAME} -v ${DRV_VERSION} -k ${KERNEL_VERSION}
+dkms build -m ${DRV_NAME} -v ${DRV_VERSION} -k ${KERNEL_VERSION}
+dkms install -m ${DRV_NAME} -v ${DRV_VERSION} -k ${KERNEL_VERSION}
 RESULT=$?
 
 echo "Finished running dkms install steps."


### PR DESCRIPTION
Allows a running system to have the driver compiled for, say, an incoming (new/updated/different) kernel, prior to reboot. Avoids the new system not having the required driver on boot.

See issue https://github.com/awesometic/realtek-r8125-dkms/issues/80

This script may now, optionally, be passed a kernel version as an ENV, for example:

```sh
$ KERNEL_VERSION=6.14.8-2-bpo12-pve ./dkms-install.sh
```